### PR TITLE
Fix scss-compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "xo && ava --verbose",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
-    "scss-compile": "node-sass --include-path scss --output-style compressed ./scss/style.scss ./assets/style.css",
+    "scss-compile": "node node_modules/.bin/node-sass --include-path scss --output-style compressed scss/style.scss assets/style.css",
     "postinstall": "npm run scss-compile"
   },
   "dependencies": {


### PR DESCRIPTION
```sh
> pdfify-node@2.2.0 postinstall ~/github/probot-pdfify/node_modules/pdfify-node
> npm run scss-compile


> pdfify-node@2.2.0 scss-compile ~/github/probot-pdfify/node_modules/pdfify-node
> node-sass --include-path scss --output-style compressed ./scss/style.scss ./assets/style.css

{
  "status": 1,
  "file": "~/github/probot-pdfify/node_modules/pdfify-node/scss/style.scss",
  "line": 1,
  "column": 1,
  "message": "File to import not found or unreadable: ../node_modules/highlight.js/styles/default.\nParent style sheet: ~/github/probot-pdfify/node_modules/pdfify-node/scss/style.scss",
  "formatted": "Error: File to import not found or unreadable: ../node_modules/highlight.js/styles/default.\n       Parent style sheet: ~/github/probot-pdfify/node_modules/pdfify-node/scss/style.scss\n        on line 1 of scss/style.scss\n>> @import \"../node_modules/highlight.js/styles/default\";\n   ^\n"
}

npm ERR! Darwin 16.5.0
npm ERR! argv "~/.nvm/versions/node/v7.9.0/bin/node" "~/.nvm/versions/node/v7.9.0/bin/npm" "run" "scss-compile"
npm ERR! node v7.9.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! pdfify-node@2.2.0 scss-compile: `node-sass --include-path scss --output-style compressed ./scss/style.scss ./assets/style.css`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the pdfify-node@2.2.0 scss-compile script 'node-sass --include-path scss --output-style compressed ./scss/style.scss ./assets/style.css'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the pdfify-node package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-sass --include-path scss --output-style compressed ./scss/style.scss ./assets/style.css
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs pdfify-node
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls pdfify-node
npm ERR! There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! Please include the following file with any support request:
npm ERR!     ~/.npm/_logs/2017-04-12T07_19_57_869Z-debug.log
npm ERR! Darwin 16.5.0
npm ERR! argv "~/.nvm/versions/node/v7.9.0/bin/node" "~/.nvm/versions/node/v7.9.0/bin/npm" "install" "pdfify-node" "--save"
npm ERR! node v7.9.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1

npm ERR! pdfify-node@2.2.0 postinstall: `npm run scss-compile`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the pdfify-node@2.2.0 postinstall script 'npm run scss-compile'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the pdfify-node package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run scss-compile
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs pdfify-node
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls pdfify-node
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     ~/.npm/_logs/2017-04-12T07_19_59_973Z-debug.log
```